### PR TITLE
Fix SpreedsheetExtraction not picking last row sometimes last row

### DIFF
--- a/Tabula/PageArea.cs
+++ b/Tabula/PageArea.cs
@@ -159,8 +159,8 @@ namespace Tabula
                 new PdfPoint(rv.Right, rv.Top)));     // getBottom
 
             rv.AddRuling(new Ruling(
-                new PdfPoint(rv.Right, rv.Bottom),
-                new PdfPoint(rv.Left, rv.Bottom)));
+                new PdfPoint(rv.Left, rv.Bottom),
+                new PdfPoint(rv.Right, rv.Bottom)));
 
             rv.AddRuling(new Ruling(
                 new PdfPoint(rv.Left, rv.Bottom),


### PR DESCRIPTION
https://github.com/BobLd/tabula-sharp/issues/25 - issue described here and confirmed by debug. The bottom boundary was being inserted in reversed x coordinate order which caused cell detection to fail.  